### PR TITLE
Upgrade .NET Aspire from 9.5.0 to 13.4.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Angular-21-512BD4.svg" alt="Angular 21">
   <img src="https://img.shields.io/badge/.NET-10-512BD4.svg" alt=".NET 10">
   <img src="https://img.shields.io/badge/PostgreSQL-17-336791.svg" alt="PostgreSQL 17">
-  <img src="https://img.shields.io/badge/Aspire-9.5-6C3483.svg" alt=".NET Aspire 9.5">
+  <img src="https://img.shields.io/badge/Aspire-13.4-6C3483.svg" alt=".NET Aspire 13.4">
 </p>
 
 <p align="center">
@@ -30,7 +30,7 @@ A production-ready **full-stack starter kit** built with modern technologies and
 - **Frontend**: Angular 21 with signals, Material Design, TailwindCSS v4, and Fluent Design
 - **Backend**: .NET 10 API with Clean Architecture and Scalar API documentation
 - **Database**: PostgreSQL 17 with pgAdmin and Dapper ORM
-- **Orchestration**: .NET Aspire 9.5 for local development with service discovery
+- **Orchestration**: .NET Aspire 13.4 for local development with service discovery
 - **DevOps**: Docker, GitHub Actions, NGINX
 
 Perfect for developers who want to **focus on business logic** instead of configuring infrastructure.
@@ -241,7 +241,7 @@ Comprehensive documentation is available:
 | API Docs | Scalar | 2.1 |
 | Database | PostgreSQL | 17 |
 | ORM | Dapper | 2.1 |
-| Orchestration | .NET Aspire | 9.5 |
+| Orchestration | .NET Aspire | 13.4 |
 | Containerization | Docker | Latest |
 
 ## 🤝 Contributing

--- a/aspire/AppHost/AppHost.cs
+++ b/aspire/AppHost/AppHost.cs
@@ -23,7 +23,7 @@ var api = builder.AddProject<Projects.Contact_Api>("contact-api")
     });
 
 // Angular Frontend
-var frontend = builder.AddNpmApp("frontend", "../../frontend", "serve")
+var frontend = builder.AddJavaScriptApp("frontend", "../../frontend", "serve")
     .WithReference(api)
     .WaitFor(api)
     .WithHttpEndpoint(targetPort: 4200, env: "PORT")

--- a/aspire/AppHost/Contact.AppHost.csproj
+++ b/aspire/AppHost/Contact.AppHost.csproj
@@ -1,6 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
-  <Sdk Name="Aspire.AppHost.Sdk" Version="9.5.0" />
+<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -11,9 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.5.0" />
-    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="9.5.0" />
-    <PackageReference Include="Aspire.Hosting.NodeJs" Version="9.5.0" />
+    <!-- Aspire.Hosting.AppHost is implicit via the Aspire.AppHost.Sdk in 13.x -->
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.4.6" />
+    <!-- Aspire.Hosting.NodeJs was renamed to Aspire.Hosting.JavaScript in 13.0; AddNpmApp -> AddJavaScriptApp in AppHost.cs -->
+    <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.4.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/aspire/ServiceDefaults/Contact.ServiceDefaults.csproj
+++ b/aspire/ServiceDefaults/Contact.ServiceDefaults.csproj
@@ -10,13 +10,13 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.0.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.14.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.9.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.9.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
   </ItemGroup>
 
 </Project>

--- a/frontend/proxy.conf.js
+++ b/frontend/proxy.conf.js
@@ -1,8 +1,13 @@
+// Aspire 13's AddJavaScriptApp (Aspire.Hosting.JavaScript) injects service-discovery
+// env vars as CONTACT_API_HTTPS / CONTACT_API_HTTP (upper-snake-case) — a different,
+// shell-safe convention from the old AddNpmApp/Aspire.Hosting.NodeJs one, which used
+// dotted names like services__contact-api__https__0 (not usable in Aspire 13, and not
+// a valid shell identifier to begin with, since resource names may contain hyphens).
 const PROXY_CONFIG = [
   {
     context: ['/api'],
-    target: process.env['services__contact-api__https__0'] || 
-            process.env['services__contact-api__http__0'] || 
+    target: process.env['CONTACT_API_HTTPS'] ||
+            process.env['CONTACT_API_HTTP'] ||
             'http://localhost:5217',
     secure: false,
     changeOrigin: true,


### PR DESCRIPTION
## Summary

Four major Aspire versions in one jump, kept isolated from the other refresh PRs (#33, #34) given the risk profile.

- **AppHost SDK declaration**: `Sdk Name="Aspire.AppHost.Sdk" Version="9.5.0"` (separate `<Sdk>` element) → `Project Sdk="Aspire.AppHost.Sdk/13.4.6"` (declared directly on `<Project>`). The SDK now implicitly includes `Aspire.Hosting.AppHost`, so that explicit package reference is removed.
- **Package rename**: `Aspire.Hosting.NodeJs` → `Aspire.Hosting.JavaScript` (13.0). `AppHost.cs` updated: `AddNpmApp("frontend", "../../frontend", "serve")` → `AddJavaScriptApp("frontend", "../../frontend", "serve")` — same parameter order/meaning, only the method and package name changed. `AddNpmApp` no longer exists in 13.x.
- `Aspire.Hosting.PostgreSQL` bumped to match (all `Aspire.*` packages in one AppHost must share a version).
- `ServiceDefaults`' OpenTelemetry/resilience/service-discovery packages refreshed to current stable lines alongside it: `Microsoft.Extensions.Http.Resilience`/`Microsoft.Extensions.ServiceDiscovery` 10.0.0 → 10.9.0, `OpenTelemetry.*` 1.14.0 → 1.17.0.
- README version badges/table updated 9.5 → 13.4.

## Verified

- `dotnet build Contact.Api.sln -c Release` — 0 errors, both `Contact.AppHost` and `Contact.ServiceDefaults` compile against the new SDK.
- `dotnet run --project aspire/AppHost` — actually started. Log confirms `Aspire AppHost version: 13.4.6`, the dashboard came up, and it drove Docker to launch the Postgres + pgAdmin containers (confirmed via `docker ps` mid-run).

## Known, unrelated

`Contact.Api.csproj` reports a `Microsoft.OpenApi` vulnerability via NuGet's audit check (NU1903). Not introduced here (no `Contact.Api` files touched in this PR) — flagging for a separate fix.

## Test plan

- [x] Full solution build, 0 errors
- [x] AppHost starts and orchestrates containers
- [ ] Full end-to-end browser walkthrough (login + contact CRUD) across all three open PRs together — in progress as a pre-merge gate, will report separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)