### PR TITLE
Fix: register Dapper type handler for DateOnly (Contact creation was broken)

### DIFF
--- a/backend/Contact.Infrastructure/InfrastructureServiceCollectionExtensions.cs
+++ b/backend/Contact.Infrastructure/InfrastructureServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Contact.Infrastructure.ExternalServices;
 using Contact.Infrastructure.Persistence;
 using Contact.Infrastructure.Persistence.Helper;
 using Contact.Infrastructure.Persistence.Repositories;
+using Dapper;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -14,6 +15,10 @@ public static class InfrastructureServiceCollectionExtensions
 {
     public static IServiceCollection AddInfrastrcutureServices(this IServiceCollection services, IConfiguration configuration)
     {
+        // Dapper has no built-in DateOnly support (ContactPerson.DateOfBirth); see
+        // DateOnlyTypeHandler for why this is needed on every insert/update.
+        SqlMapper.AddTypeHandler(new DateOnlyTypeHandler());
+
         services.Configure<AppSettings>(configuration.GetSection("AppSettings"));
         services.Configure<SmtpSettings>(configuration.GetSection("SmtpSettings"));
 

--- a/backend/Contact.Infrastructure/Persistence/Helper/DateOnlyTypeHandler.cs
+++ b/backend/Contact.Infrastructure/Persistence/Helper/DateOnlyTypeHandler.cs
@@ -1,0 +1,27 @@
+using System.Data;
+using Dapper;
+
+namespace Contact.Infrastructure.Persistence.Helper;
+
+/// <summary>
+/// Dapper has no built-in support for System.DateOnly — ADO.NET's DbType enum predates
+/// it, so passing a DateOnly parameter throws NotSupportedException at the driver level.
+/// Npgsql maps PostgreSQL's "date" column type to DateOnly on read without issue; only
+/// the outbound parameter direction needs this handler. Registered once at startup via
+/// InfrastructureServiceCollectionExtensions.AddInfrastrcutureServices.
+/// </summary>
+public sealed class DateOnlyTypeHandler : SqlMapper.TypeHandler<DateOnly>
+{
+    public override void SetValue(IDbDataParameter parameter, DateOnly value)
+    {
+        parameter.DbType = DbType.Date;
+        parameter.Value = value.ToDateTime(TimeOnly.MinValue);
+    }
+
+    public override DateOnly Parse(object value) => value switch
+    {
+        DateOnly dateOnly => dateOnly,
+        DateTime dateTime => DateOnly.FromDateTime(dateTime),
+        _ => throw new NotSupportedException($"Cannot convert {value.GetType()} to DateOnly."),
+    };
+}

--- a/frontend/src/app/feature/contact/contact-form/contact-form.component.ts
+++ b/frontend/src/app/feature/contact/contact-form/contact-form.component.ts
@@ -60,6 +60,14 @@ export class ContactFormComponent implements OnInit {
     onSubmit(): void {
         if (this.formValid()) {
             const contact = this.contactForm.value;
+            // matDatepicker stores a JS Date on the control; JSON.stringify would send
+            // a full ISO instant (e.g. "1990-01-15T05:00:00.000Z"), which the API's
+            // System.Text.Json DateOnly converter rejects (it wants a bare "yyyy-MM-dd").
+            // Format using local date components, not toISOString(), so a timezone whose
+            // offset crosses midnight doesn't shift the calendar day by one.
+            if (contact.dateOfBirth) {
+                contact.dateOfBirth = this.toDateOnlyString(contact.dateOfBirth);
+            }
             this.loading.set(true);
 
             if (this.isEditMode()) {
@@ -181,5 +189,13 @@ export class ContactFormComponent implements OnInit {
     private formatDate(jsonDate: string): string {
       const date = new Date(jsonDate);
       return date.toISOString().split('T')[0]; // yyyy-MM-dd format
+    }
+
+    private toDateOnlyString(value: Date | string): string {
+        const date = value instanceof Date ? value : new Date(value);
+        const year = date.getFullYear();
+        const month = String(date.getMonth() + 1).padStart(2, '0');
+        const day = String(date.getDate()).padStart(2, '0');
+        return `${year}-${month}-${day}`;
     }
 }


### PR DESCRIPTION
## Summary

Discovered via a full end-to-end browser test (login + contact CRUD) against a live Aspire stack, requested as a pre-merge gate for #33/#34/#35. Not part of the scope of any of those PRs — this is a **pre-existing bug**, unrelated to the Mapperly, Angular, or Aspire upgrades.

Creating a contact through the UI failed with a 500. Direct API call surfaced the real error:

```
"The member DateOfBirth of type System.DateOnly cannot be used as a parameter value" (NotSupportedException)
```

Dapper has no built-in support for `System.DateOnly` — ADO.NET's `DbType` enum predates it, so any INSERT/UPDATE binding a `DateOnly` parameter throws. `ContactPerson.DateOfBirth` has been `DateOnly` since the contact-seeding feature was first added (confirmed via `git log` — predates everything else in this repo's recent history), and no type handler was ever registered. **Contact creation has likely never worked through this API.**

Reads were unaffected — Npgsql maps PostgreSQL `date` columns to `DateOnly` on the way out without issue, which is why the 10 seeded contacts always displayed correctly and this went unnoticed. Nothing in CI exercises the create path (no E2E tests), and a developer checking the UI would see a populated list without ever needing to add one.

## Fix

`DateOnlyTypeHandler` (`Contact.Infrastructure/Persistence/Helper/`), registered once via `SqlMapper.AddTypeHandler` in `InfrastructureServiceCollectionExtensions.AddInfrastrcutureServices`.

## Test plan

- [x] `dotnet build backend/Contact.Api/Contact.Api.csproj -c Release` — 0 errors
- [x] Direct `POST /api/ContactPerson` with a `dateOfBirth` field — confirmed fixed against a live Aspire-orchestrated stack (was 500, now succeeds)
- [x] Full browser E2E (login, create, list, edit, delete) — see the coordinating summary across all four open PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)