### PR TITLE
Sync docs site version footer to v3.0.0

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -5,8 +5,8 @@ remote_theme: just-the-docs/just-the-docs
 url: https://nitin27may.github.io/clean-architecture-docker-dotnet-angular
 
 # Version information
-version: "2.1.0"
-last_updated: "2023-06-15"
+version: "3.0.0"
+last_updated: "2026-08-20"
 build_timestamp: <%= Time.now.to_i %>
 
 # Cache busting settings


### PR DESCRIPTION
Trivial follow-up to the v3.0.0 release (https://github.com/nitin27may/clean-architecture-docker-dotnet-angular/releases/tag/v3.0.0). `docs/_config.yml`'s `version`/`last_updated` fields drive the Jekyll site's footer — was still showing `2.1.0` / `2023-06-15`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)