### PR TITLE
seo: link out to the blog and the sibling doc sites

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -40,6 +40,11 @@ search_tokenizer_separator: /[\s/]+/
 aux_links:
   "View on GitHub":
     - "//github.com/nitin27may/clean-architecture-docker-dotnet-angular"
+  # This site had no link out of it anywhere -- not to the blog it is published
+  # under, not to its sibling doc sites. That is the real reason Search Console
+  # reported it as never crawled: nothing on the web pointed here.
+  "nitinksingh.com":
+    - "/"
 
 # Footer content
 footer_content: "Copyright &copy; 2026 Nitin Singh. Distributed under the MIT License."
@@ -81,6 +86,17 @@ gh_edit_view_mode: "tree"
 nav_external_links:
   - title: Clean Architecture on GitHub
     url: https://github.com/nitin27may/clean-architecture-docker-dotnet-angular
+    hide_icon: false
+  # The sibling doc sites, all published under the same domain. Trailing slashes
+  # are required: GitHub Pages 301s the unslashed form of a directory index.
+  - title: AI Knowledge Hub
+    url: https://nitinksingh.com/ai-resources/
+    hide_icon: false
+  - title: E-Commerce Agents
+    url: https://nitinksingh.com/e-commerce-agents/
+    hide_icon: false
+  - title: MEAN Stack with Docker
+    url: https://nitinksingh.com/mean-docker/
     hide_icon: false
 
 # Back to top link


### PR DESCRIPTION
## Why

This site is a leaf — every link in it points back into itself. Nothing goes to `nitinksingh.com`, which it's published under, and nothing to the three sibling doc sites on the same domain.

That's not cosmetic. Search Console reports this site as **"URL is unknown to Google"**: never crawled once. Not "crawled and not indexed" — Google has never heard of it.

The sitemap is live and now submitted, but a sitemap only declares what exists; it doesn't create the crawl demand to go fetch it. With no inbound link from anywhere on the web, there was nothing else to act on.

A crawl of all four project sites found the same shape in every one. Three of the four are in this state.

## What changed

`docs/_config.yml` only.

- `aux_links` renders top-right on every page, so one key buys a site-wide link back to the blog.
- `nav_external_links` gets the three siblings.

Trailing slashes are deliberate — GitHub Pages 301s the unslashed form of a directory index.

## Verification

Built with the real CI image (`ghcr.io/actions/jekyll-build-pages`): the built index emits a link to `/` plus all three siblings, and still renders exactly one `<h1>`.

## Noted, not changed

10 of the 12 pages have a `<title>` over 60 chars and get truncated in results — entirely because the site-title suffix *"Clean Architecture with .NET, Angular and Docker"* is 48 characters on its own. You asked to keep the new site titles, so this is left as an accepted trade-off. Shortening `title:` in `docs/_config.yml` would fix all 10 at once if you change your mind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)